### PR TITLE
Release 1.1.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,13 +3,22 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased] 0000-00-00
+## [UNRELEASED] 0000-00-00
+
+## [1.1.3] 2017-08-21
 #### Fixed
 
+- Fixed misleading error about NickServ when connecting to IRC
+- Limited IRC messages to 256 chars. Long messages will be split and sent in chunks.
 - IRC connector now handles newlines returned from Legos (#129, #140, #142) (@bbriggs)
   - With improvements from @pry0cc
-
 - Fixed a nasty bug where a response directed at one user or channel would be sent to a channel or user of the same name on another connector. (#141, #143) (@bbriggs)
+- Messages sent to a user-id in Slack now properly route to the DM channel (#163).
+
+### Added
+
+- New Utilities class to provide convenience methods for legos
+- Slack connector now has methods to resolve a user-id to a username and a user-id to a DM channel id
 
 ## [1.1.2] 2017-02-08
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.1.3] 2017-08-21
 #### Fixed
 
-- Fixed misleading error about NickServ when connecting to IRC
+- Fixed misleading error about NickServ when connecting to IRC (#154) (@Nitr4x)
 - Limited IRC messages to 256 chars. Long messages will be split and sent in chunks.
 - IRC connector now handles newlines returned from Legos (#129, #140, #142) (@bbriggs)
   - With improvements from @pry0cc

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@ from setuptools import setup, find_packages
 setup(
     name='Legobot',
 
-    version='1.1.2',
+    version='1.1.3',
 
     license='GPLv2',
 
     py_modules=['Legobot'],
 
-    description="A framework for creating interactive chatbots on various"
+    description="A framework for creating interactive chatbots on various "
     "protocols",
 
     author="Kevin McCabe, Bren Briggs, and Drew Bronson",


### PR DESCRIPTION
Add any fixes to the changelog for 1.1.3 here.

## [1.1.3] 2017-08-21
#### Fixed

- Fixed misleading error about NickServ when connecting to IRC (#154) (@Nitr4x)
- Limited IRC messages to 256 chars. Long messages will be split and sent in chunks.
- IRC connector now handles newlines returned from Legos (#129, #140, #142) (@bbriggs)
  - With improvements from @pry0cc
- Fixed a nasty bug where a response directed at one user or channel would be sent to a channel or user of the same name on another connector. (#141, #143) (@bbriggs)
- Messages sent to a user-id in Slack now properly route to the DM channel (#163).

### Added

- New Utilities class to provide convenience methods for legos
- Slack connector now has methods to resolve a user-id to a username and a user-id to a DM channel id