### PR TITLE
Added subcommands to Legos.Help, allowing for help regarding individu…

### DIFF
--- a/Legobot/Legos/Help.py
+++ b/Legobot/Legos/Help.py
@@ -54,9 +54,9 @@ class Help(Lego):
                         try:
                             help_str = lego_proxy.get_help(sub=sub).get()
                         except (TypeError, KeyError):
-                            help_str = (function + 
-                                ' does not have any further help regarding ' +
-                                sub)
+                            help_str = (function +
+                                        ' has no information on ' +
+                                        sub)
                     except IndexError:
                         help_str = lego_proxy.get_help().get()
 

--- a/Legobot/Legos/Help.py
+++ b/Legobot/Legos/Help.py
@@ -49,7 +49,14 @@ class Help(Lego):
             for lego in legos:
                 lego_proxy = lego.proxy()
                 if lego_proxy.get_name().get() == function:
-                    help_str = lego_proxy.get_help().get()
+                    try:
+                        subcommand = message['text'].split()[2]
+                        try:
+                            help_str = lego_proxy.get_help(sub=subcommand).get()
+                        except TypeError:
+                            help_str = function + ' does not have any further help regarding ' + subcommand
+                    except IndexError:
+                        help_str = lego_proxy.get_help().get()
 
         opts = {'target': target}
 

--- a/Legobot/Legos/Help.py
+++ b/Legobot/Legos/Help.py
@@ -50,11 +50,13 @@ class Help(Lego):
                 lego_proxy = lego.proxy()
                 if lego_proxy.get_name().get() == function:
                     try:
-                        subcommand = message['text'].split()[2]
+                        sub = message['text'].split()[2]
                         try:
-                            help_str = lego_proxy.get_help(sub=subcommand).get()
-                        except TypeError:
-                            help_str = function + ' does not have any further help regarding ' + subcommand
+                            help_str = lego_proxy.get_help(sub=sub).get()
+                        except (TypeError, KeyError):
+                            help_str = (function + 
+                                ' does not have any further help regarding ' +
+                                sub)
                     except IndexError:
                         help_str = lego_proxy.get_help().get()
 


### PR DESCRIPTION
Legos with the current `get_help()` function will work as is.
If you want to add additional help functionality to a lego you need to modify the `get_help()` to look like this:

```
get_help(self, **kwargs):
subcommands = {'foo':'food does bar', 'this':'this is sort of like that'}
if ('sub' in kwargs):
    return subcommands[kwargs['sub']]
else:
    return "This is the default help text returned when asking only for `get_help()`"
```
For further example on modifying `get_help()` and to see a working example checkout my testing branch of [lego.memes][0]

[0]: https://github.com/pard68/legos.memes/tree/testing