### PR TITLE
Feature name channel translation in slack message text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Legos/
 Source/
 Test/.cache/
 __pycache__/
+.DS_Store
+.cache/
+.vscode/

--- a/Legobot/Connectors/Slack.py
+++ b/Legobot/Connectors/Slack.py
@@ -120,7 +120,7 @@ class RtmBot(threading.Thread, object):
         '''
 
         match = True
-        pattern = re.compile('<@([A-Z0-9]+)>')
+        pattern = re.compile('<@([A-Z0-9]{9})>')
         while match:
             match = pattern.search(text)
             if match:
@@ -140,7 +140,7 @@ class RtmBot(threading.Thread, object):
         '''
 
         match = True
-        pattern = re.compile('<#([A-Z0-9]+)\|([A-Za-z0-9-]+)>')
+        pattern = re.compile('<#([A-Z0-9]{9})\|([A-Za-z0-9-]+)>')
         while match:
             match = pattern.search(text)
             if match:

--- a/Legobot/Connectors/Slack.py
+++ b/Legobot/Connectors/Slack.py
@@ -345,6 +345,9 @@ class Slack(Lego):
                 message['text'] = message['text'].replace(match,
                                                           '<{}>'.format(match))
 
+            if message['text'].find('<<@') != -1:
+                mesage['text'] = message['text'].replace('<<', '<')
+                mesage['text'] = message['text'].replace('>>', '>')
             logger.debug('MESSAGE TEXT: {}'.format(message['text']))
             if target.startswith('U'):
                 target = self.botThread.get_dm_channel(target)

--- a/Legobot/Connectors/Slack.py
+++ b/Legobot/Connectors/Slack.py
@@ -85,6 +85,9 @@ class RtmBot(threading.Thread, object):
                           metadata=metadata).__dict__
         if message.get('text'):
             message['text'] = self.find_and_replace_userids(message['text'])
+            message['text'] = self.find_and_replace_channel_refs(
+                message['text']
+            )
         return message
 
     def run(self):
@@ -106,7 +109,7 @@ class RtmBot(threading.Thread, object):
         return
 
     def find_and_replace_userids(self, text):
-        '''Finds occurrences of Slack userids and attempts to replace them wtih
+        '''Finds occurrences of Slack userids and attempts to replace them with
            display names.
 
         Args:
@@ -122,6 +125,25 @@ class RtmBot(threading.Thread, object):
             if match:
                 name = self.get_user_display_name(match.group(1))
                 text = re.sub(re.compile(match.group(0)), '@' + name, text)
+
+        return text
+
+    def find_and_replace_channel_refs(self, text):
+        '''Find occurrences of Slack channel referenfces and attempts to
+           replace them with just channel names.
+
+        Args:
+            text (string): The message text
+        Returns:
+            string: The message text with channel references replaced.
+        '''
+
+        match = True
+        pattern = re.compile('<#([A-Z0-9]+)\|([A-Za-z0-9-]+)>')
+        while match:
+            match = pattern.search(text)
+            if match:
+                text = text.replace(match.group(0), '#' + match.group(2))
 
         return text
 

--- a/Legobot/Connectors/Slack.py
+++ b/Legobot/Connectors/Slack.py
@@ -400,10 +400,17 @@ class Slack(Lego):
         logger.debug(message)
         if Utilities.isNotEmpty(message['metadata']['opts']):
             target = message['metadata']['opts']['target']
-            pattern = re.compile('@([a-zA-Z0-9._-]+)')
+            # pattern = re.compile('@([a-zA-Z0-9._-]+)')
+            pattern = re.compile('^@([a-zA-Z0-9._-]+)|\s@([a-zA-Z0-9._-]+)')
             matches = re.findall(pattern, message['text'])
             matches = set(matches)
+            logger.debug('MATCHES!!!!   {}'.format(matches))
             for match in matches:
+                if isinstance(match, tuple):
+                    if match[0] != '':
+                        match = match[0]
+                    else:
+                        match = match[1]
                 if not match.startswith('@'):
                     match = '@' + match
                 message['text'] = message['text'].replace(

--- a/Legobot/Connectors/Slack.py
+++ b/Legobot/Connectors/Slack.py
@@ -80,11 +80,6 @@ class RtmBot(threading.Thread, object):
         Returns:
             Legobot.messge
         '''
-        #if event.get('files'):
-        #    del event['files']
-
-        #if event.get('attachments'):
-        #    del event['attachments']
 
         metadata = self._parse_metadata(event)
         message = Message(text=metadata['text'],

--- a/Legobot/Connectors/Slack.py
+++ b/Legobot/Connectors/Slack.py
@@ -80,6 +80,12 @@ class RtmBot(threading.Thread, object):
         Returns:
             Legobot.messge
         '''
+        #if event.get('files'):
+        #    del event['files']
+
+        #if event.get('attachments'):
+        #    del event['attachments']
+
         metadata = self._parse_metadata(event)
         message = Message(text=metadata['text'],
                           metadata=metadata).__dict__
@@ -266,9 +272,16 @@ class RtmBot(threading.Thread, object):
             string: Human-friendly name of the user
         '''
 
-        for member in self.get_users()['members']:
-            if member['id'] == userid:
-                return member['name']
+        username = userid
+        users = self.get_users()
+        if users:
+            members = users.get('members')
+            if members:
+                for member in members:
+                    if member.get('id') == userid:
+                        username = member.get('name')
+
+        return username
 
     def get_userid_from_botid(self, botid):
         '''Perform a lookup of bots.info to resolve a botid to a userid

--- a/Legobot/Connectors/Slack.py
+++ b/Legobot/Connectors/Slack.py
@@ -124,7 +124,7 @@ class RtmBot(threading.Thread, object):
                 text = re.sub(re.compile(match.group(0)), '@' + name, text)
 
         return text
-    
+
     def get_user_id_by_name(self, name):
         users = self.get_users(condensed=True)
         if not users:
@@ -141,7 +141,7 @@ class RtmBot(threading.Thread, object):
         if name in users_transform.keys():
             return users_transform[name]
         else:
-            return name       
+            return name
 
     def get_users(self, condensed=False):
         '''Grabs all users in the slack team
@@ -346,8 +346,8 @@ class Slack(Lego):
                                                           '<{}>'.format(match))
 
             if message['text'].find('<<@') != -1:
-                mesage['text'] = message['text'].replace('<<', '<')
-                mesage['text'] = message['text'].replace('>>', '>')
+                message['text'] = message['text'].replace('<<', '<')
+                message['text'] = message['text'].replace('>>', '>')
             logger.debug('MESSAGE TEXT: {}'.format(message['text']))
             if target.startswith('U'):
                 target = self.botThread.get_dm_channel(target)

--- a/Legobot/Connectors/Slack.py
+++ b/Legobot/Connectors/Slack.py
@@ -336,6 +336,16 @@ class Slack(Lego):
         logger.debug(message)
         if Utilities.isNotEmpty(message['metadata']['opts']):
             target = message['metadata']['opts']['target']
+            pattern = re.compile('@([a-zA-Z0-9._-]+)')
+            matches = re.findall(pattern, message['text'])
+            matches = set(matches)
+            for match in matches:
+                if not match.startswith('@'):
+                    match = '@' + match
+                message['text'] = message['text'].replace(match,
+                                                          '<{}>'.format(match))
+
+            logger.debug('MESSAGE TEXT: {}'.format(message['text']))
             if target.startswith('U'):
                 target = self.botThread.get_dm_channel(target)
             self.botThread.slack_client.rtm_send_message(target,

--- a/Legobot/Legos/Help.py
+++ b/Legobot/Legos/Help.py
@@ -54,9 +54,9 @@ class Help(Lego):
                         try:
                             help_str = lego_proxy.get_help(sub=sub).get()
                         except (TypeError, KeyError):
-                            help_str = (function + 
-                                ' does not have any further help regarding ' +
-                                sub)
+                            help_str = (function +
+                                        ' has no information on ' +
+                                        sub)
                     except IndexError:
                         help_str = lego_proxy.get_help().get()
 

--- a/Legobot/Legos/Help.py
+++ b/Legobot/Legos/Help.py
@@ -49,7 +49,14 @@ class Help(Lego):
             for lego in legos:
                 lego_proxy = lego.proxy()
                 if lego_proxy.get_name().get() == function:
-                    help_str = lego_proxy.get_help().get()
+                    try:
+                        subcommand = message['text'].split()[2]
+                        try:
+                            help_str = lego_proxy.get_help(sub=subcommand).get()
+                        except TypeError:
+                            help_str = function + ' does not have any further help regarding ' + subcommand
+                    except IndexError:
+                        help_str = lego_proxy.get_help().get()
 
         opts = {'target': target}
 

--- a/Legobot/Legos/Help.py
+++ b/Legobot/Legos/Help.py
@@ -50,11 +50,13 @@ class Help(Lego):
                 lego_proxy = lego.proxy()
                 if lego_proxy.get_name().get() == function:
                     try:
-                        subcommand = message['text'].split()[2]
+                        sub = message['text'].split()[2]
                         try:
-                            help_str = lego_proxy.get_help(sub=subcommand).get()
-                        except TypeError:
-                            help_str = function + ' does not have any further help regarding ' + subcommand
+                            help_str = lego_proxy.get_help(sub=sub).get()
+                        except (TypeError, KeyError):
+                            help_str = (function + 
+                                ' does not have any further help regarding ' +
+                                sub)
                     except IndexError:
                         help_str = lego_proxy.get_help().get()
 


### PR DESCRIPTION
Slack does funny things with user and channel references. this seeks to automatically encode/decode them in the slack connector (in the message text) to that the message text is usable for addressing these items.