### PR TITLE
Added a __main__.py entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ __pycache__/
 .DS_Store
 .cache/
 .vscode/
+test_config.yaml
+config.yaml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.7] 2021-10-07
+
+### Added
+
+- Default entrypoint
+- Added `--config`/`-c` flag to specify a path to a config
+
 ## [1.3.6] 2021-05-26
 
 ### Added

--- a/Legobot/__main__.py
+++ b/Legobot/__main__.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
+from pathlib import Path
+from Legobot.Chatbot import Chatbot
+
 def main():
-    from pathlib import Path
-    from Legobot.Chatbot import Chatbot
     bot = Chatbot(Path(__file__).resolve().parent.joinpath('config.yaml'))
     bot.run()
 

--- a/Legobot/__main__.py
+++ b/Legobot/__main__.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+def main():
+    from pathlib import Path
+    from Legobot.Chatbot import Chatbot
+    bot = Chatbot(Path(__file__).resolve().parent.joinpath('config.yaml'))
+    bot.run()
+
+if __name__ == "__main__":
+    main()

--- a/Legobot/__main__.py
+++ b/Legobot/__main__.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 
+import click
 from pathlib import Path
 from Legobot.Chatbot import Chatbot
 
-def main():
-    bot = Chatbot(Path(__file__).resolve().parent.joinpath('config.yaml'))
+@click.command()
+@click.option('-c', '--config', default="config.yaml", help="Path to your config, defaults to './config.yaml'")
+def main(config):
+    bot = Chatbot(Path(__file__).resolve().parent.joinpath(config))
     bot.run()
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 irc==17.0
+click==8.0
 jmespath==0.10.0
 jsonschema==3.2.0
 pykka==1.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = Legobot
-version = 1.3.6
+version = 1.3.7
 author = Kevin McCabe, Bren Briggs, and Drew Bronson, Drew Pearce
 url = https://github.com/bbriggs/Legobot
 description = A framework for creating interactive chatbots on various protocols


### PR DESCRIPTION
With a `config.yaml` there is no need to import this into a
`chatbot.py`. Instead just configure it in the yaml and then call
`Legobot`, ie `python3 Legobot`. I'd like to add some basic argv
support, but that's sorta out of scope for this I think, also would hate
to do that effort only for it to be rejected because the use of a
`__main__.py` is unwanted.

HMU if you like this and want to see some argv support added in this pr.